### PR TITLE
feat: optimize cache durations for better performance

### DIFF
--- a/docs/caching.md
+++ b/docs/caching.md
@@ -43,8 +43,9 @@ client.vocabulary.search("diabetes", domain_id="Condition", page_size=50)
 The following methods are automatically cached:
 
 ### High-Value Targets
-- `client.concept_sets.list()` - 10 minute cache (expensive: 20K+ items)
-- `client.concept_sets.get(id)` - 5 minute cache
+- `client.concept_sets.list()` - 1 hour cache (expensive: 20K+ items)
+- `client.concept_sets.get(id)` - 30 minute cache (stable individual sets)
+- `client.concept_sets.resolve(id)` - 30 minute cache (resolved concept lists)
 - `client.vocabulary.get_concept(id)` - 1 hour cache (concepts rarely change)
 - `client.vocabulary.domains()` - 30 minute cache (stable metadata)
 
@@ -57,7 +58,7 @@ client = WebApiClient("https://atlas-demo.ohdsi.org/WebAPI")
 # First call: hits API (~10 seconds for 27K concept sets)
 concept_sets = client.concept_sets.list()
 
-# Second call: instant (from cache)
+# Subsequent calls: instant (from cache for 1 hour)
 concept_sets = client.concept_sets.list()  # ~10,000x faster!
 ```
 

--- a/src/ohdsi_webapi/services/concept_sets.py
+++ b/src/ohdsi_webapi/services/concept_sets.py
@@ -18,7 +18,7 @@ class ConceptSetService:
     def __init__(self, http: HttpExecutor):
         self._http = http
 
-    @cached_method(ttl_seconds=600)  # 10 minutes for expensive list operation
+    @cached_method(ttl_seconds=3600)  # 1 hour for expensive list operation (20K+ items)
     def list(self, *, force_refresh: bool = False) -> list[ConceptSet]:
         """List all concept sets (metadata only).
 
@@ -118,7 +118,7 @@ class ConceptSetService:
             # Fetch full details on demand
             yield self.get(cs_metadata.id)
 
-    @cached_method(ttl_seconds=300)  # 5 minutes for individual concept sets
+    @cached_method(ttl_seconds=1800)  # 30 minutes for individual concept sets
     def get(self, concept_set_id: int, *, force_refresh: bool = False) -> ConceptSet:
         """Get a concept set by ID with full details including expression.
 
@@ -162,6 +162,7 @@ class ConceptSetService:
         data = self._http.post(f"/conceptset/{concept_set_id}/expression", json_body=expression)
         return data if isinstance(data, dict) else {}
 
+    @cached_method(ttl_seconds=1800)  # 30 minutes for concept set resolution
     def resolve(self, concept_set_id: int) -> list[ConceptSetItem]:
         """Get the concept set items (concepts) in a concept set.
 


### PR DESCRIPTION
- Increase concept_sets.list() cache from 10min to 1 hour (20K+ items)
- Increase concept_sets.get() cache from 5min to 30 minutes
- Add concept_sets.resolve() caching at 30 minutes (expensive operation)
- Update caching documentation with new durations

Performance improvements:
- list(): 6x longer cache for 20,000+ concept set metadata
- get(): 6x longer cache for individual concept sets
- resolve(): NEW cache for expensive resolution operations

These changes significantly improve user experience for data exploration workflows where concept sets are frequently accessed.