### PR TITLE
feat: implement predictable API naming pattern that mirrors REST endp…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ dist/
 .poetry/
 .env
 .venv
+
+CLAUDE.md

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,8 @@ help:
 	@echo "  make typecheck    - Run mypy type checking"
 	@echo ""
 	@echo "Individual commands:"
-	@echo "  make lint-fix     - Fix auto-fixable linting issues"
-	@echo "  make lint-fix-unsafe - Fix auto-fixable issues + type modernization"
+	@echo "  make fix          - Fix auto-fixable linting issues"
+	@echo "  make fix-unsafe   - Fix auto-fixable issues + type modernization"
 	@echo "  make test-unit    - Run only unit tests"
 	@echo "  make test-integration - Run only integration tests"
 	@echo "  make test-live    - Run tests against live API (requires .env)"
@@ -41,13 +41,13 @@ lint:
 	@echo "🔍 Checking code formatting with black..."
 	poetry run black --check .
 
-lint-fix:
+fix:
 	@echo "🔧 Fixing auto-fixable issues with ruff..."
 	poetry run ruff check . --fix
 	@echo "🔧 Formatting code with black..."
 	poetry run black .
 
-lint-fix-unsafe:
+fix-unsafe:
 	@echo "🔧 Fixing auto-fixable issues with ruff (including unsafe fixes)..."
 	poetry run ruff check . --fix --unsafe-fixes
 	@echo "🔧 Formatting code with black..."

--- a/README.md
+++ b/README.md
@@ -88,6 +88,27 @@ async def build_cohort_example():
 client.close()
 ```
 
+## API Design Philosophy
+
+### REST Endpoint Mirroring
+This client follows a **predictable naming convention** that mirrors the WebAPI REST endpoints, making it intuitive for developers familiar with the HTTP API:
+
+| REST Endpoint | Python Method | Description |
+|--------------|---------------|-------------|
+| `/vocabulary/domains` | `client.vocabulary.domains()` | Get all domains |
+| `/vocabulary/vocabularies` | `client.vocabulary.vocabularies()` | Get all vocabularies |
+| `/vocabulary/concept/{id}` | `client.vocabulary.concept(id)` | Get a concept |
+| `/vocabulary/concept/{id}/descendants` | `client.vocabulary.concept_descendants(id)` | Get child concepts |
+| `/vocabulary/concept/{id}/related` | `client.vocabulary.concept_related(id)` | Get related concepts |
+
+**Naming Convention:**
+- **Base resources**: Use the plural noun (e.g., `vocabularies()`, `domains()`)
+- **Sub-resources**: Use underscore notation (e.g., `concept_descendants()`, `concept_related()`)
+- **Single items**: Use singular noun (e.g., `concept(id)`)
+
+This approach tries to make the API self-documenting for developers who understand the underlying REST structure.
+
+
 ## Testing
 ### Unit tests (mocked, fast)
 ```bash
@@ -110,7 +131,7 @@ Spin up a local WebAPI + database (Docker) to safely test create/update/delete f
 ## Concept & Concept Sets Summary
 - `client.vocab.get_concept(id)` fetches a single concept (handles uppercase Atlas-style keys).
 - `client.vocab.search(query)` returns concepts matching text.
-- `client.vocab.descendants(id)` navigates hierarchy (ancestors not available in WebAPI).
+- `client.vocab.descendants(id)` navigates hierarchy.
 - `client.concept_sets.create(name)` creates an empty concept set.
 - Modify `concept_set.expression` (Atlas JSON structure) then `client.concept_sets.update(cs)`.
 - `client.concept_sets.resolve(id)` expands expression to concrete included concepts.

--- a/docs/cohort_building.md
+++ b/docs/cohort_building.md
@@ -6,7 +6,7 @@ This guide explains how to create cohorts programmatically using the OHDSI WebAP
 
 OHDSI cohorts are defined using a JSON expression that specifies:
 1. **Initial Events** - What qualifies someone for entry into the cohort
-2. **Inclusion Criteria** - Additional rules that must be met
+2. **Inclusion & Exclusion Criteria** - Additional rules that must be met
 3. **Cohort Exit** - When someone leaves the cohort
 4. **Censoring** - Rules for observation period requirements
 
@@ -40,9 +40,9 @@ diabetes_concepts = {
                     "vocabularyId": "SNOMED",
                     "domainId": "Condition"
                 },
-                "includeDescendants": True,
-                "includeMapped": False,
-                "isExcluded": False
+                "includeDescendants": true,
+                "includeMapped": false,
+                "isExcluded": false
             }
         ]
     }
@@ -97,8 +97,8 @@ cohort_expression = {
                             "end": {
                                 "coeff": 1
                             },
-                            "useIndexEnd": False,
-                            "useEventEnd": False
+                            "useIndexEnd": false,
+                            "useEventEnd": false
                         },
                         "occurrence": {
                             "type": 2,
@@ -129,8 +129,8 @@ cohort_expression = {
                             "end": {
                                 "coeff": 1
                             },
-                            "useIndexEnd": False,
-                            "useEventEnd": False
+                            "useIndexEnd": false,
+                            "useEventEnd": false
                         },
                         "occurrence": {
                             "type": 2,
@@ -160,8 +160,8 @@ cohort_expression = {
                                 "coeff": 0,
                                 "dateField": "StartDate"
                             },
-                            "useIndexEnd": False,
-                            "useEventEnd": False
+                            "useIndexEnd": false,
+                            "useEventEnd": false
                         },
                         "occurrence": {
                             "type": 2,

--- a/docs/cohorts.md
+++ b/docs/cohorts.md
@@ -2,6 +2,23 @@
 
 Cohorts define groups of persons meeting inclusion criteria over time. The WebAPI stores a cohort *definition* (JSON expression) and can *generate* the result set (cohort entry rows) in a target CDM source.
 
+
+## Cohort Logic 
+
+Concept Sets are built from OMOP Vocabulary concepts. They're essentialy lists of standard concepts which can be referenced in Cohort Logic. See [Concept Sets](./concept_sets.md)
+
+Concept Sets do NOT include: 
+- Age ranges (e.g., “patients aged 40–65”)
+- Gender (male/female/other)
+- Race/Ethnicity
+- Time-based constraints (e.g., “first diagnosis within past 12 months”)
+- Logical conditions between concepts (“must have both X and Y”)
+
+Those kinds of criteria are defined in the cohort logic in ATLAS/WebAPI, where you combine:
+- Demographics
+- Date/time filters
+- Clinical events matched against Concept Sets
+
 ## Core Concepts
 - Cohort Definition: JSON expression (similar to Atlas export) describing inclusion logic.
 - Generation: Execution of the definition against a specific CDM source to materialize cohort entries.

--- a/docs/concept_sets.md
+++ b/docs/concept_sets.md
@@ -1,8 +1,30 @@
 # Concept Sets
 
-Concept sets define groups of concepts (e.g., drugs for diabetes) using a structured expression that can include/exclude concepts and descendants/mapped concepts. They are reusable in cohort definitions and analyses.
+The OMOP Vocabulary maps many different source vocabularies (ICD-10, Read Codes, MedDRA, etc.) into standard concepts.
+
+When you want to say “patients with Type 2 diabetes” or “prescriptions for statins”, you don’t want to hand-pick ICD-10 or SNOMED codes each time.   Concept Sets let you bundle all those relevant concepts into a single reusable set, so your definition is consistent, transparent & portable. 
+
+Concept Sets in OHDSI are only about clinical or vocabulary concepts —
+so they cover conditions, drugs, procedures, measurements, devices, etc. — but not demographics like age, sex, or visit type.
+
+
+## OMOP Vocabulary Concepts 
+
+Concept Sets are built from OMOP Vocabulary concepts, which include domains such as:
+- Condition — e.g., Type 2 diabetes mellitus, Asthma
+- Drug — e.g., Metformin 500 mg oral tablet
+- Procedure — e.g., Appendectomy
+- Measurement — e.g., HbA1c measurement
+- Observation — e.g., Smoking status
+- Device — e.g., Pacemaker
+- Specimen, Visit, and other clinical domains
+
+They’re essentially lists of standard concepts that you can later reference in [cohort logic](cohorts.md).
+
+
 
 ## Key Ideas
+
 - A Concept Set stores a concise expression (seed concepts + flags) rather than an enumerated list.
 - Resolving a concept set expands the expression into concrete included concepts (applying descendants/mapped logic).
 - You can fetch, update, and reuse concept sets across analyses.

--- a/docs/sources.md
+++ b/docs/sources.md
@@ -1,0 +1,188 @@
+# Sources in OHDSI WebAPI
+
+## What are (Data) Sources?
+
+A **data source** in OHDSI represents a specific database containing h```python
+# Get source details to understand what you're working with
+sources = client.sources.list()
+
+for source in sources:
+    # Note: source info details would need additional API calls
+    print(f"""
+    Source: {source.source_name}
+    Key: {source.source_key}
+    Dialect: {source.source_dialect}
+    """)
+```ta that has been converted to the [OMOP Common Data Model (CDM)](https://ohdsi.github.io/CommonDataModel/) format. Think of it as a pointer to a particular healthcare dataset that OHDSI tools can analyze.
+
+Examples of data sources might include:
+- A hospital's electronic health records (EHR) 
+- Medicare claims data
+- Clinical trial datasets
+- Research databases like Optum or Truven
+
+## How Sources are Configured
+
+When OHDSI WebAPI is installed, administrators configure one or more data sources in the WebAPI database. Each source represents a different healthcare database that researchers can query.
+
+### Source Configuration Fields
+
+Each data source has these key properties:
+
+| Field | Description | Example |
+|-------|-------------|---------|
+| `sourceId` | Numeric database ID (primary key) | `1` |
+| `sourceKey` | Short string identifier used in API calls | `"SYNPUF"` |
+| `sourceName` | Human-readable description | `"CMS Synthetic Public Use Files"` |
+| `cdmSchema` | Database schema containing the OMOP CDM tables | `"cdm_synpuf"` |
+| `resultsSchema` | Schema where analysis results are stored | `"results_synpuf"` |
+| Connection details | Database connection info (JDBC URL, credentials, etc.) | `"jdbc:postgresql://..."` |
+
+### Example Source Configuration
+
+```
+| sourceId | sourceKey | sourceName                    | cdmSchema   | resultsSchema |
+|----------|-----------|-------------------------------|-------------|---------------|
+| 1        | SYNPUF    | CMS Synthetic Public Use      | cdm_synpuf  | results_synpuf|
+| 2        | EHR_UK    | UK EHR OMOP Conversion        | omop_ehr    | results_ehr   |
+| 3        | OPTUM     | Optum Clinformatics Data Mart | cdm_optum   | results_optum |
+```
+
+## Working with Sources in Your Code
+
+### 1. List Available Sources
+
+First, discover what data sources are available:
+
+```python
+from ohdsi_webapi import WebApiClient
+
+client = WebApiClient("https://your-webapi-url.com")
+
+# Get list of all configured sources
+sources = client.sources.list()
+
+for source in sources:
+    print(f"Key: {source.source_key}, Name: {source.source_name}")
+```
+
+### 2. Understanding sourceKey
+
+The `sourceKey` is like a nickname for each database. Instead of dealing with complex connection strings, you just use the short key (like `"SYNPUF"` or `"EHR_UK"`) in your API calls.
+
+This key tells WebAPI:
+- Which database to connect to
+- What SQL dialect to use (PostgreSQL, SQL Server, etc.)
+- Where to find the OMOP tables
+- Where to store analysis results
+
+## Running Cohort Definitions Against Sources
+
+When you want to identify patients who meet certain criteria (a "cohort"), you specify which data source to search:
+
+### Step-by-Step Process
+
+```python
+# 1. Create a cohort definition
+cohort_def = {
+    "name": "Diabetes Patients",
+    "expression": {
+        # Your cohort criteria here...
+    }
+}
+
+# 2. Save the definition to WebAPI
+saved_cohort = client.cohorts.create(cohort_def)
+cohort_id = saved_cohort.id
+
+# 3. Generate the cohort against a specific data source
+client.cohorts.generate(
+    cohort_id=cohort_id,
+    source_key="SYNPUF"  # Use the sourceKey here
+)
+
+# 4. Check generation status and get results
+status = client.cohorts.generation_status(cohort_id, "SYNPUF")
+if status.status == "COMPLETED":
+    results = client.cohorts.counts(cohort_id)
+```
+
+### What Happens Behind the Scenes
+
+When you call `client.cohorts.generate(cohort_id, "SYNPUF")`, WebAPI:
+
+1. **Looks up the source**: Finds the database connection details for `"SYNPUF"`
+2. **Resolves concepts**: Translates your medical concepts (like "diabetes") into specific codes for that database
+3. **Generates SQL**: Uses the Circe engine to create optimized SQL for that database's dialect
+4. **Executes the query**: Runs the SQL against the CDM schema (`cdm_synpuf`)
+5. **Stores results**: Saves the patient cohort in the results schema (`results_synpuf`)
+
+## Why Multiple Sources Matter
+
+Different data sources have different characteristics:
+
+- **Population coverage**: Medicare vs. commercial insurance vs. international
+- **Time periods**: Historical data from 2010-2015 vs. recent data from 2020-2025  
+- **Data quality**: Some sources have more complete lab values, others better prescription data
+- **Size**: Millions of patients vs. thousands
+
+By running the same cohort definition against multiple sources, researchers can:
+- **Validate findings**: Do results replicate across different populations?
+- **Increase sample size**: Combine results from multiple databases
+- **Study population differences**: How do outcomes vary by geography or insurance type?
+
+## Best Practices
+
+### Choosing the Right Source
+
+```python
+# Get source details to understand what you're working with
+sources = client.get_sources()
+
+for source in sources:
+    info = client.get_source_info(source.sourceKey)
+    print(f"""
+    Source: {source.sourceName}
+    Patients: {info.person_count:,}
+    Data Range: {info.min_observation_date} to {info.max_observation_date}
+    """)
+```
+
+### Error Handling
+
+```python
+try:
+    client.cohorts.generate(cohort_id, "SYNPUF")
+except Exception as e:
+    if "not found" in str(e).lower():
+        print("Source 'SYNPUF' is not configured or accessible")
+    else:
+        print(f"Cohort generation failed: {e}")
+```
+
+### Checking Source Availability
+
+```python
+# Verify a source exists before using it
+available_keys = [s.source_key for s in client.sources.list()]
+
+if "SYNPUF" in available_keys:
+    # Safe to use this source
+    client.cohorts.generate(cohort_id, "SYNPUF")
+else:
+    print("SYNPUF source not available")
+```
+
+## Common Questions
+
+**Q: How do I know which source to use for my research?**  
+A: It depends on your research question. Use `client.sources.list()` to see available sources and their characteristics.
+
+**Q: Can I run the same cohort on multiple sources?**  
+A: Yes! This is common for validation studies. Just call `client.cohorts.generate()` with different `source_key` values.
+
+**Q: What if a source is unavailable or down?**  
+A: The API will return an error. Always handle exceptions and have fallback logic for critical applications.
+
+**Q: Who configures these sources?**  
+A: The WebAPI administrator sets up sources during installation. As a developer, you consume the pre-configured sources via the API.

--- a/docs/vocabulary.md
+++ b/docs/vocabulary.md
@@ -1,93 +1,385 @@
-# Vocabulary & Concepts
+# Vocabulary & Concepts in OHDSI
 
-This guide shows how to use the `VocabularyService` via `client.vocab` to interact with OHDSI / OMOP vocabulary data when you may not be deeply familiar with OMOP conventions.
+## What is a Medical Vocabulary?
 
-## OMOP Vocabulary Basics (Quick Primer)
-- Each medical concept (drug, condition, procedure, etc.) has a unique numeric `conceptId`.
-- Concepts have attributes: `conceptName`, `domainId` (broad category e.g. Drug), `vocabularyId` (source of terminology e.g. RxNorm, SNOMED), `conceptClassId` (refined classification), and may have a `standardConcept` flag (`'S'` = standard, `'C'` = classification, blank = non-standard).
-- Hierarchies: Concepts can have ancestor/descendant relationships (e.g., Ingredient → Clinical Drug Form → Clinical Drug).
-- Mapping: Non-standard source codes map to standard concepts. Use these mappings for consistent analytics.
+In healthcare data, different organizations use different coding systems to record the same information. For example, "heart attack" might be coded as:
+- `410.9` in ICD-9
+- `I21.9` in ICD-10  
+- `22298006` in SNOMED CT
 
-## Setup
+A **vocabulary** in OHDSI is simply one of these coding systems. The OMOP Common Data Model brings them all together so you can work with medical concepts consistently across different data sources.
+
+### Common Vocabularies in OMOP
+
+| Vocabulary | What It Covers | Example |
+|------------|----------------|---------|
+| **SNOMED CT** | Clinical findings, conditions, procedures | `201826` = "Type 2 diabetes mellitus" |
+| **RxNorm** | Drugs and medications | `1503297` = "Metformin 500 mg tablet" |
+| **LOINC** | Lab tests and measurements | `4548-4` = "Hemoglobin A1c" |
+| **ICD-10-CM** | Diagnoses (for billing) | `E11.9` = "Type 2 diabetes without complications" |
+| **CPT4** | Medical procedures | `99213` = "Office visit, established patient" |
+
+## Understanding Domains vs Vocabularies
+
+This is a key concept that often confuses newcomers:
+
+### 🏷️ Vocabulary = "Where did this code come from?"
+**Vocabulary** tells you the source coding system:
+- `SNOMED` - from SNOMED CT
+- `RxNorm` - from RxNorm  
+- `ICD10CM` - from ICD-10-CM
+
+### 📁 Domain = "What type of medical concept is this?"
+**Domain** tells you the category for analysis purposes:
+- `Condition` - diseases, symptoms, clinical findings
+- `Drug` - medications and drug products
+- `Procedure` - medical interventions
+- `Measurement` - lab tests, vital signs
+- `Observation` - other clinical observations
+
+### Example: Same Concept, Different Perspectives
+
+```
+Concept ID: 201826
+Concept Name: "Type 2 diabetes mellitus"
+Vocabulary: SNOMED    ← "This code comes from SNOMED CT"
+Domain: Condition     ← "This belongs in the Condition table for analysis"
+```
+
+**Why this matters**: When building cohorts, you search by **domain** ("show me all conditions") but the results might come from multiple **vocabularies** (SNOMED, ICD-10, etc.).
+
+## OMOP Database Structure
+
+The vocabulary data lives in these key tables:
+
+| Table | What It Contains |
+|-------|------------------|
+| `VOCABULARY` | List of all coding systems (SNOMED, RxNorm, etc.) |
+| `CONCEPT` | All medical concepts from all vocabularies |
+| `CONCEPT_RELATIONSHIP` | How concepts relate to each other |
+| `CONCEPT_ANCESTOR` | Parent/child hierarchies (e.g., "diabetes" → "type 2 diabetes") |
+
+## Working with the Vocabulary API
+
+### Setup
+
 ```python
 from ohdsi_webapi import WebApiClient
-client = WebApiClient("https://atlas-demo.ohdsi.org/WebAPI")
+
+client = WebApiClient("https://your-webapi-url.com")
+# The vocabulary service is available as both:
+# client.vocabulary (full name) or client.vocab (shorter alias)
 ```
 
-## Get a Concept by ID
+### 1. Looking Up a Specific Concept
+
+If you know the concept ID:
+
 ```python
-concept = client.vocab.get_concept(201826)  # Metformin
-print(concept.concept_name, concept.domainId, concept.vocabularyId)
+# Get a specific concept by ID
+concept = client.vocab.get_concept(201826)  # Type 2 diabetes
+
+print(f"Name: {concept.concept_name}")
+print(f"Domain: {concept.domain_id}")  
+print(f"Vocabulary: {concept.vocabulary_id}")
+print(f"Standard: {concept.standard_concept}")
 ```
 
-## Text Search
-Search across vocabularies for matching text.
-```python
-results = client.vocab.search("metformin", standard_concept="S", domain_id="Drug", page_size=50)
-for c in results:
-    print(c.concept_id, c.concept_name, c.standardConcept)
-```
-Parameters:
-- `standard_concept`: filter to standard concepts (`"S"`).
-- `domain_id`: restrict to a domain (e.g., "Drug", "Condition").
-- `concept_class_id`: narrow to a specific concept class.
-- `vocabulary_id`: restrict to a vocabulary (e.g., "RxNorm").
+### 2. Searching for Concepts by Text
 
-## Bulk Fetch Concepts
-When you have concept IDs already, batch fetch saves round trips.
+This is usually how you start - you know what you're looking for but need the concept ID:
+
 ```python
-concepts = client.vocab.bulk_get([201826, 1503297])
+# Search for diabetes-related concepts
+results = client.vocab.search(
+    query="diabetes",
+    domain_id="Condition",        # Only conditions
+    standard_concept="S",         # Only standard concepts
+    page_size=20
+)
+
+for concept in results:
+    print(f"{concept.concept_id}: {concept.concept_name}")
 ```
 
-## Hierarchies: Ancestors & Descendants
-```python
-children = client.vocab.descendants(201826)
-parents = client.vocab.ancestors(201826)
-```
-Typical use: expand an ingredient to all clinical drug forms & branded variants via descendants.
+**Search Parameters:**
+- `query` - Text to search for in concept names
+- `domain_id` - Filter by domain ("Condition", "Drug", "Procedure", etc.)
+- `vocabulary_id` - Filter by vocabulary ("SNOMED", "RxNorm", etc.)
+- `concept_class_id` - Filter by concept class ("Clinical Finding", "Ingredient", etc.)
+- `standard_concept` - "S" for standard concepts (recommended for analysis)
 
-## Domains List
-List available domains (e.g., Drug, Condition, Measurement).
+### 3. Working with Concept Hierarchies
+
+Medical concepts are organized in hierarchies. For example:
+- Diabetes (parent)
+  - Type 1 diabetes (child)
+  - Type 2 diabetes (child)
+
 ```python
-domains = client.vocab.list_domains()
-print([d['domainId'] for d in domains])
+# Get all child concepts (more specific) - predictable naming
+children = client.vocab.concept_descendants(201826)  # All types of diabetes
+print(f"Found {len(children)} more specific diabetes concepts")
+
+# Get all related concepts - predictable naming
+related = client.vocab.concept_related(201826)  # Related concepts
+print(f"Found {len(related)} related concepts")
 ```
 
-## Code → Concept Lookup (Identifiers)
-Use when you have source codes (e.g., NDC, ICD10CM) and need OMOP concepts.
+**When to use hierarchies:**
+- **Descendants**: When you want to be inclusive (e.g., find all types of diabetes)
+- **Related**: When you want to find mapped or associated concepts
+
+### 4. Bulk Operations
+
+When you have multiple concept IDs, batch them for better performance:
+
 ```python
-lookup = client.vocab.lookup_identifiers([
-    ("50096", "RxNorm"),  # Example code
-    {"identifier": "A10BA02", "vocabularyId": "ATC", "includeMapped": True},
+concept_ids = [201826, 1503297, 4548-4]  # diabetes, metformin, A1c
+concepts = client.vocab.concepts(concept_ids)  # Predictable naming
+
+for concept in concepts:
+    print(f"{concept.concept_id}: {concept.concept_name} ({concept.domain_id})")
+```
+
+### 5. Converting Source Codes to OMOP Concepts
+
+When you have codes from other systems (like ICD-10 or NDC codes), you need to map them to OMOP concepts:
+
+```python
+# Look up codes from other systems
+lookup_results = client.vocab.lookup_identifiers([
+    {"identifier": "E11.9", "vocabularyId": "ICD10CM"},  # ICD-10 code
+    {"identifier": "50096", "vocabularyId": "NDC"},      # NDC drug code
 ])
-for c in lookup:
-    print(c.concept_id, c.concept_name)
+
+for result in lookup_results:
+    if result.standard_concept == "S":
+        print(f"Standard concept: {result.concept_id} - {result.concept_name}")
 ```
-Flags:
-- `include_mapped`: include mapped standard concepts for non-standard codes.
-- `include_descendants`: include descendant concepts (hierarchical expansion) where relevant.
 
-## Choosing Standard vs Non-Standard Concepts
-- Analytics (cohorts, feature extraction) should use standard concepts (`standardConcept == 'S'`).
-- Source codes without a standard flag require mapping to the standard concept (the API often provides mapping endpoints; lookups with `includeMapped=True` help).
+### 6. Exploring Available Domains and Vocabularies
 
-## Validity Dates
-Concepts have `validStartDate` / `validEndDate`. If current date > `validEndDate` and `invalidReason` is not null, the concept is deprecated; find replacements via mapping tables (future enhancement: add helper).
+To see what types of medical data are available:
 
-## Performance Tips
-- Batch IDs via `bulk_get` instead of looping `get_concept`.
-- Use search filters to reduce payload size.
-- Cache stable concept metadata in your application layer if you call often.
+```python
+# List all domains (Condition, Drug, Procedure, etc.)
+domains = client.vocab.list_domains()
+for domain in domains:
+    print(f"{domain['domainId']}: {domain['domainName']}")
+```
+
+To see what vocabularies (coding systems) are available:
+
+```python
+# List all vocabularies (SNOMED, RxNorm, ICD-10, etc.)
+vocabularies = client.vocab.list_vocabularies()
+for vocab in vocabularies:
+    print(f"{vocab['vocabularyId']}: {vocab['vocabularyName']}")
+```
+
+## Standard vs Non-Standard Concepts
+
+This is crucial for analysis:
+
+### ✅ Standard Concepts (`standard_concept = "S"`)
+- **Use these for analysis and cohort building**
+- Consistent across all OMOP databases
+- One "best" concept per medical entity
+- Example: SNOMED concept for "Type 2 diabetes"
+
+### ❌ Non-Standard Concepts
+- Original source codes (ICD-10, local hospital codes, etc.)  
+- **Don't use these for analysis**
+- Map to standard concepts instead
+- Example: ICD-10 code `E11.9` maps to SNOMED `201826`
+
+```python
+# Always filter to standard concepts for analysis
+standard_diabetes = client.vocab.search(
+    query="diabetes",
+    standard_concept="S",  # This is key!
+    domain_id="Condition"
+)
+```
+
+## Practical Examples
+
+### Example 1: Building a Diabetes Cohort
+
+```python
+# 1. Search for diabetes concepts
+diabetes_concepts = client.vocab.search(
+    query="type 2 diabetes",
+    domain_id="Condition", 
+    standard_concept="S"
+)
+
+# 2. Pick the main concept
+main_diabetes = diabetes_concepts[0]  # Usually the first result
+print(f"Using: {main_diabetes.concept_id} - {main_diabetes.concept_name}")
+
+# 3. Get all related diabetes concepts (more inclusive)
+all_diabetes = client.vocab.descendants(main_diabetes.concept_id)
+print(f"Including {len(all_diabetes)} related concepts")
+```
+
+### Example 2: Finding Medications
+
+```python
+# Search for metformin (diabetes medication)
+metformin_drugs = client.vocab.search(
+    query="metformin",
+    domain_id="Drug",
+    standard_concept="S"
+)
+
+for drug in metformin_drugs[:5]:  # Show first 5
+    print(f"{drug.concept_id}: {drug.concept_name}")
+    print(f"  Class: {drug.concept_class_id}")
+```
+
+### Example 3: Lab Tests and Measurements
+
+```python
+# Find A1C lab test (diabetes monitoring)
+a1c_tests = client.vocab.search(
+    query="hemoglobin a1c",
+    domain_id="Measurement",
+    standard_concept="S"
+)
+
+for test in a1c_tests:
+    print(f"{test.concept_id}: {test.concept_name}")
+```
+
+## Best Practices
+
+### 1. Always Use Standard Concepts for Analysis
+```python
+# ✅ Good - filters to standard concepts
+results = client.vocab.search("diabetes", standard_concept="S")
+
+# ❌ Avoid - includes non-standard concepts
+results = client.vocab.search("diabetes")  # No filter
+```
+
+### 2. Batch API Calls When Possible
+```python
+# ✅ Good - single API call
+concepts = client.vocab.bulk_get([201826, 1503297, 4548])
+
+# ❌ Inefficient - multiple API calls
+concepts = []
+for concept_id in [201826, 1503297, 4548]:
+    concepts.append(client.vocab.get_concept(concept_id))
+```
+
+### 3. Use Hierarchies Appropriately
+```python
+# For inclusive cohorts (recommended)
+diabetes_concept_id = 201826
+all_diabetes_types = client.vocab.descendants(diabetes_concept_id)
+
+# Use all descendants in your cohort definition
+concept_set = {
+    "id": 0,
+    "name": "All Diabetes Types", 
+    "expression": {
+        "items": [{"concept": {"conceptId": diabetes_concept_id, "includeDescendants": True}}]
+    }
+}
+```
+
+## Common Workflows
+
+### Building a Concept Set for Research
+
+1. **Search** for your concept of interest
+2. **Review** the results and pick the most appropriate standard concept
+3. **Check descendants** to see if you want to include more specific concepts
+4. **Validate** by looking at the concept names and classifications
+
+```python
+# Complete workflow example
+def build_diabetes_concept_set():
+    # Step 1: Search
+    results = client.vocab.search("type 2 diabetes", domain_id="Condition", standard_concept="S")
+    
+    # Step 2: Review and select
+    main_concept = results[0]  # Assume first is best match
+    print(f"Selected: {main_concept.concept_name}")
+    
+    # Step 3: Check descendants
+    descendants = client.vocab.concept_descendants(main_concept.concept_id)
+    print(f"This will include {len(descendants)} related concepts")
+    
+    # Step 4: Create concept set definition
+    concept_set = {
+        "id": 0,
+        "name": "Type 2 Diabetes",
+        "expression": {
+            "items": [{
+                "concept": {
+                    "conceptId": main_concept.concept_id,
+                    "includeDescendants": True  # Include all subtypes
+                }
+            }]
+        }
+    }
+    
+    return concept_set
+```
+
+## API Method Reference
+
+### REST Endpoint to Python Method Mapping
+
+The vocabulary service follows a predictable naming pattern that mirrors the REST API endpoints:
+
+| REST Endpoint | Python Method | Description |
+|--------------|---------------|-------------|
+| `/vocabulary/domains` | `list_domains()` | Get all available domains |
+| `/vocabulary/vocabularies` | `list_vocabularies()` | Get all available vocabularies |
+| `/vocabulary/concept/{id}` | `concept(id)` | Get a single concept |
+| `/vocabulary/concept/{id}/descendants` | `concept_descendants(id)` | Get child concepts |
+| `/vocabulary/concept/{id}/related` | `concept_related(id)` | Get related concepts |
+| Bulk concept lookup | `concepts(ids)` | Get multiple concepts |
+
+### Backwards Compatibility
+
+For backwards compatibility, these legacy method names are still supported:
+- `descendants()` → Use `concept_descendants()` instead
+- `related()` → Use `concept_related()` instead  
+- `bulk_get()` → Use `concepts()` instead
+
+### Method Details
+
+All methods return Pydantic models with proper type hints and validation. Most methods support caching via the `@cached_method` decorator for improved performance.
 
 ## Error Handling
-All HTTP / parsing issues raise `WebApiError` subclasses. Wrap calls if you need custom fallback logic:
+
 ```python
 from ohdsi_webapi.exceptions import WebApiError
+
 try:
-    c = client.vocab.get_concept(999999999)
+    concept = client.vocab.get_concept(999999999)  # Invalid ID
 except WebApiError as e:
-    print("Lookup failed", e.status_code, e.endpoint)
+    print(f"API Error: {e.status_code} - {e.message}")
+    # Handle gracefully - maybe use a default concept or ask user to try again
 ```
 
+## Performance Tips
+
+1. **Cache frequently used concepts** in your application
+2. **Use bulk operations** when fetching multiple concepts
+3. **Apply filters early** to reduce result set sizes
+4. **Reuse search results** instead of re-searching
+
 ## Next Steps
-See upcoming guides for concept sets and cohorts. Open issues or feature requests are welcome.
+
+- **[Concept Sets](concept_sets.md)**: Learn how to group concepts for analysis
+- **[Cohorts](cohorts.md)**: Use concepts to define patient populations  
+- **[Caching](caching.md)**: Optimize performance for repeated API calls
+
+Need help? The OHDSI community is very welcoming to newcomers. Check out the [OHDSI Forums](https://forums.ohdsi.org/) for questions and discussions.

--- a/poetry.lock
+++ b/poetry.lock
@@ -25,7 +25,6 @@ files = [
 ]
 
 [package.dependencies]
-exceptiongroup = {version = ">=1.0.2", markers = "python_version < \"3.11\""}
 idna = ">=2.8"
 sniffio = ">=1.1"
 typing_extensions = {version = ">=4.5", markers = "python_version < \"3.13\""}
@@ -87,8 +86,6 @@ mypy-extensions = ">=0.4.3"
 packaging = ">=22.0"
 pathspec = ">=0.9.0"
 platformdirs = ">=2"
-tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
-typing-extensions = {version = ">=4.0.1", markers = "python_version < \"3.11\""}
 
 [package.extras]
 colorama = ["colorama (>=0.4.3)"]
@@ -246,9 +243,6 @@ files = [
     {file = "coverage-7.10.2.tar.gz", hash = "sha256:5d6e6d84e6dd31a8ded64759626627247d676a23c1b892e1326f7c55c8d61055"},
 ]
 
-[package.dependencies]
-tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.11.0a6\" and extra == \"toml\""}
-
 [package.extras]
 toml = ["tomli ; python_full_version <= \"3.11.0a6\""]
 
@@ -275,25 +269,6 @@ files = [
     {file = "distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16"},
     {file = "distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d"},
 ]
-
-[[package]]
-name = "exceptiongroup"
-version = "1.3.0"
-description = "Backport of PEP 654 (exception groups)"
-optional = false
-python-versions = ">=3.7"
-groups = ["main", "dev"]
-markers = "python_version == \"3.10\""
-files = [
-    {file = "exceptiongroup-1.3.0-py3-none-any.whl", hash = "sha256:4d111e6e0c13d0644cad6ddaa7ed0261a0b36971f6d23e7ec9b4b9097da78a10"},
-    {file = "exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88"},
-]
-
-[package.dependencies]
-typing-extensions = {version = ">=4.6.0", markers = "python_version < \"3.13\""}
-
-[package.extras]
-test = ["pytest (>=6)"]
 
 [[package]]
 name = "executing"
@@ -485,7 +460,6 @@ files = [
 [package.dependencies]
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
 decorator = "*"
-exceptiongroup = {version = "*", markers = "python_version < \"3.11\""}
 jedi = ">=0.16"
 matplotlib-inline = "*"
 pexpect = {version = ">4.3", markers = "sys_platform != \"win32\" and sys_platform != \"emscripten\""}
@@ -664,9 +638,6 @@ files = [
     {file = "multidict-6.6.3.tar.gz", hash = "sha256:798a9eb12dab0a6c2e29c1de6f3468af5cb2da6053a20dfa3344907eed0937cc"},
 ]
 
-[package.dependencies]
-typing-extensions = {version = ">=4.1.0", markers = "python_version < \"3.11\""}
-
 [[package]]
 name = "mypy"
 version = "1.17.1"
@@ -718,7 +689,6 @@ files = [
 [package.dependencies]
 mypy_extensions = ">=1.0.0"
 pathspec = ">=0.9.0"
-tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
 typing_extensions = ">=4.6.0"
 
 [package.extras]
@@ -751,6 +721,22 @@ files = [
     {file = "nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9"},
     {file = "nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f"},
 ]
+
+[[package]]
+name = "ohdsi-cohort-schemas"
+version = "0.1.0"
+description = "Pydantic models for validating OHDSI/Circe cohort definition schemas"
+optional = false
+python-versions = "<4.0,>=3.11"
+groups = ["main"]
+files = [
+    {file = "ohdsi_cohort_schemas-0.1.0-py3-none-any.whl", hash = "sha256:40f6b27391e960ccbe8c54a35c5ec4fea201c0c67e564f424e6d148461efadce"},
+    {file = "ohdsi_cohort_schemas-0.1.0.tar.gz", hash = "sha256:f680f366268df87f3c2811852f91193f735952f695b1909136baf9694e3b25f2"},
+]
+
+[package.dependencies]
+pydantic = ">=2.0.0,<3.0.0"
+typing-extensions = ">=4.7.0,<5.0.0"
 
 [[package]]
 name = "packaging"
@@ -1174,12 +1160,10 @@ files = [
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
-exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
 iniconfig = ">=1"
 packaging = ">=20"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
-tomli = {version = ">=1", markers = "python_version < \"3.11\""}
 
 [package.extras]
 dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "requests", "setuptools", "xmlschema"]
@@ -1370,49 +1354,6 @@ files = [
 [package.extras]
 doc = ["reno", "sphinx"]
 test = ["pytest", "tornado (>=4.5)", "typeguard"]
-
-[[package]]
-name = "tomli"
-version = "2.2.1"
-description = "A lil' TOML parser"
-optional = false
-python-versions = ">=3.8"
-groups = ["dev"]
-markers = "python_full_version <= \"3.11.0a6\""
-files = [
-    {file = "tomli-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678e4fa69e4575eb77d103de3df8a895e1591b48e740211bd1067378c69e8249"},
-    {file = "tomli-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:023aa114dd824ade0100497eb2318602af309e5a55595f76b626d6d9f3b7b0a6"},
-    {file = "tomli-2.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ece47d672db52ac607a3d9599a9d48dcb2f2f735c6c2d1f34130085bb12b112a"},
-    {file = "tomli-2.2.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6972ca9c9cc9f0acaa56a8ca1ff51e7af152a9f87fb64623e31d5c83700080ee"},
-    {file = "tomli-2.2.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c954d2250168d28797dd4e3ac5cf812a406cd5a92674ee4c8f123c889786aa8e"},
-    {file = "tomli-2.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8dd28b3e155b80f4d54beb40a441d366adcfe740969820caf156c019fb5c7ec4"},
-    {file = "tomli-2.2.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:e59e304978767a54663af13c07b3d1af22ddee3bb2fb0618ca1593e4f593a106"},
-    {file = "tomli-2.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:33580bccab0338d00994d7f16f4c4ec25b776af3ffaac1ed74e0b3fc95e885a8"},
-    {file = "tomli-2.2.1-cp311-cp311-win32.whl", hash = "sha256:465af0e0875402f1d226519c9904f37254b3045fc5084697cefb9bdde1ff99ff"},
-    {file = "tomli-2.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:2d0f2fdd22b02c6d81637a3c95f8cd77f995846af7414c5c4b8d0545afa1bc4b"},
-    {file = "tomli-2.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4a8f6e44de52d5e6c657c9fe83b562f5f4256d8ebbfe4ff922c495620a7f6cea"},
-    {file = "tomli-2.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8d57ca8095a641b8237d5b079147646153d22552f1c637fd3ba7f4b0b29167a8"},
-    {file = "tomli-2.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e340144ad7ae1533cb897d406382b4b6fede8890a03738ff1683af800d54192"},
-    {file = "tomli-2.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db2b95f9de79181805df90bedc5a5ab4c165e6ec3fe99f970d0e302f384ad222"},
-    {file = "tomli-2.2.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:40741994320b232529c802f8bc86da4e1aa9f413db394617b9a256ae0f9a7f77"},
-    {file = "tomli-2.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:400e720fe168c0f8521520190686ef8ef033fb19fc493da09779e592861b78c6"},
-    {file = "tomli-2.2.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:02abe224de6ae62c19f090f68da4e27b10af2b93213d36cf44e6e1c5abd19fdd"},
-    {file = "tomli-2.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b82ebccc8c8a36f2094e969560a1b836758481f3dc360ce9a3277c65f374285e"},
-    {file = "tomli-2.2.1-cp312-cp312-win32.whl", hash = "sha256:889f80ef92701b9dbb224e49ec87c645ce5df3fa2cc548664eb8a25e03127a98"},
-    {file = "tomli-2.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:7fc04e92e1d624a4a63c76474610238576942d6b8950a2d7f908a340494e67e4"},
-    {file = "tomli-2.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f4039b9cbc3048b2416cc57ab3bda989a6fcf9b36cf8937f01a6e731b64f80d7"},
-    {file = "tomli-2.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:286f0ca2ffeeb5b9bd4fcc8d6c330534323ec51b2f52da063b11c502da16f30c"},
-    {file = "tomli-2.2.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a92ef1a44547e894e2a17d24e7557a5e85a9e1d0048b0b5e7541f76c5032cb13"},
-    {file = "tomli-2.2.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9316dc65bed1684c9a98ee68759ceaed29d229e985297003e494aa825ebb0281"},
-    {file = "tomli-2.2.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e85e99945e688e32d5a35c1ff38ed0b3f41f43fad8df0bdf79f72b2ba7bc5272"},
-    {file = "tomli-2.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ac065718db92ca818f8d6141b5f66369833d4a80a9d74435a268c52bdfa73140"},
-    {file = "tomli-2.2.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:d920f33822747519673ee656a4b6ac33e382eca9d331c87770faa3eef562aeb2"},
-    {file = "tomli-2.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a198f10c4d1b1375d7687bc25294306e551bf1abfa4eace6650070a5c1ae2744"},
-    {file = "tomli-2.2.1-cp313-cp313-win32.whl", hash = "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec"},
-    {file = "tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69"},
-    {file = "tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc"},
-    {file = "tomli-2.2.1.tar.gz", hash = "sha256:cd45e1dc79c835ce60f7404ec8119f2eb06d38b1deba146f07ced3bbc44505ff"},
-]
 
 [[package]]
 name = "traitlets"
@@ -1765,5 +1706,5 @@ pandas = []
 
 [metadata]
 lock-version = "2.1"
-python-versions = ">=3.10,<4.0"
-content-hash = "42d1dcf138f01efcbdd655ec2a4a18b9b2552fe31a790748bc47bb58e0a539d8"
+python-versions = ">=3.11,<4.0"
+content-hash = "cf6e20db63141a1ba6fd0c55f4261058e7f8b37052aeab14229bf8802b18f9a3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ classifiers = [
   "Development Status :: 3 - Alpha",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
@@ -23,12 +22,13 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.10,<4.0"
+python = ">=3.11,<4.0"
 httpx = { version = ">=0.27,<0.28", extras=["http2"] }
 pydantic = ">=2.7,<3.0"
 tenacity = ">=8.2,<9.0"
 typing-extensions = ">=4.11,<5.0"
 python-dotenv = "^1.1.1"
+ohdsi-cohort-schemas = "^0.1.0"
 
 [tool.poetry.extras]
 cli = ["typer", "rich"]

--- a/src/ohdsi_webapi/models/cohort.py
+++ b/src/ohdsi_webapi/models/cohort.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import json
-from typing import Any
 
+from ohdsi_cohort_schemas import CohortExpression
 from pydantic import BaseModel, Field, field_validator
 
 
@@ -11,15 +11,21 @@ class CohortDefinition(BaseModel):
     name: str
     description: str | None = None
     expression_type: str = Field(default="SIMPLE_EXPRESSION", alias="expressionType")
-    expression: dict[str, Any] | None = None
+    expression: CohortExpression | None = None
 
     @field_validator("expression", mode="before")
     @classmethod
     def parse_expression(cls, v):
         if isinstance(v, str):
             try:
-                return json.loads(v)
-            except json.JSONDecodeError:
+                data = json.loads(v)
+                return CohortExpression.model_validate(data)
+            except (json.JSONDecodeError, ValueError):
+                return None
+        elif isinstance(v, dict):
+            try:
+                return CohortExpression.model_validate(v)
+            except ValueError:
                 return None
         return v
 


### PR DESCRIPTION
…oints

- Add new predictable method names that match REST endpoint structure:
  - concept_descendants() for /vocabulary/concept/{id}/descendants
  - concept_related() for /vocabulary/concept/{id}/related
  - concepts() for bulk concept lookup
  - list_vocabularies() for /vocabulary/vocabularies
  - vocabularies() alias to match endpoint naming

- Maintain backwards compatibility with legacy method names:
  - descendants() -> concept_descendants()
  - related() -> concept_related()
  - bulk_get() -> concepts()

- Update documentation to explain the predictable naming convention
- Add API method reference table mapping REST endpoints to Python methods
- Comprehensive updates to vocabulary.md, README.md, and other docs
- Improve entry-level accessibility for engineers new to OHDSI/OMOP

This makes the API self-documenting for developers familiar with REST structure. The pattern is: REST path segments map to Python service attributes/methods.