### PR TITLE
feat: implement predictable API naming that mirrors REST endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,9 @@ Spin up a local WebAPI + database (Docker) to safely test create/update/delete f
 
 ## Additional Documentation
 See the docs directory for deeper guides:
+- [Supported Endpoints](docs/supported_endpoints.md) - which WebAPI endpoints are supported
 - Finding Codes: [docs/finding_codes.md](docs/finding_codes.md)
+- OHDSI (data) sources: [docs/sources.md](docs/sources.md)
 - Vocabulary & Concepts: [docs/vocabulary.md](docs/vocabulary.md)
 - Concept Sets: [docs/concept_sets.md](docs/concept_sets.md)
 - Cohorts: [docs/cohorts.md](docs/cohorts.md)

--- a/docs/supported_endpoints.md
+++ b/docs/supported_endpoints.md
@@ -1,0 +1,187 @@
+# Supported WebAPI Endpoints
+
+This page lists all OHDSI WebAPI endpoints currently supported by this Python client. The [official WebAPI documentation](http://webapidoc.ohdsi.org/index.html) shows hundreds of endpoints, but this client focuses on the core functionality needed for cohort building and vocabulary operations.
+
+## Coverage Philosophy
+
+This client prioritizes **cohort building workflows** and covers these key areas:
+- ✅ **Vocabulary & Concepts** - Search and retrieve medical concepts
+- ✅ **Concept Sets** - Create and manage reusable concept groups  
+- ✅ **Cohort Definitions** - Define and generate patient cohorts
+- ✅ **Sources** - List available data sources
+- ✅ **Info & Health** - WebAPI version and status information
+
+**Not Currently Supported:**
+- Atlas-specific UI endpoints
+- Advanced analytics (pathways, IRs, estimation, prediction)
+- Admin/security endpoints
+- Data characterization reports
+
+## Endpoint Reference
+
+### Naming Convention
+
+This client follows a **predictable naming pattern** that exactly mirrors WebAPI REST endpoints:
+
+- **Base endpoints**: `/info` → `client.info()`, `/conceptset/` → `client.conceptset()`, `/cohortdefinition/` → `client.cohortdefinition()`
+- **Resource by ID**: `/conceptset/{id}` → `client.conceptset(id)`, `/cohortdefinition/{id}` → `client.cohortdefinition(id)`, `/job/{id}` → `client.job(id)`
+- **Sub-resources**: `/conceptset/{id}/expression` → `client.conceptset_expression(id)`, `/source/sources` → `client.source_sources()`
+- **Actions**: `/cohortdefinition/{id}/generate/{source}` → `client.cohortdefinition_generate(id, source)`
+
+**Backwards Compatible Shortcuts**: For convenience, the original service-based methods (`client.concept_sets.*`, `client.cohorts.*`, `client.sources.list()`) are maintained as aliases.
+
+### 🏥 Info & Health
+
+| WebAPI Endpoint | Predictable Method | Shortcut/Alias | Description |
+|----------------|-------------------|----------------|-------------|
+| `GET /info` | `client.info()` | `client.info.get()` | WebAPI version and build info |
+
+### 📊 Data Sources
+
+| WebAPI Endpoint | Predictable Method | Shortcut/Alias | Description |
+|----------------|-------------------|----------------|-------------|
+| `GET /source/sources` | `client.source_sources()` | `client.sources.list()` | List all configured data sources |
+
+### 📖 Vocabulary & Concepts
+
+| WebAPI Endpoint | Predictable Method | Shortcut/Alias | Description |
+|----------------|-------------------|----------------|-------------|
+| `GET /vocabulary/domains` | `client.vocabulary.domains()` | `client.vocab.list_domains()` | List all OMOP domains |
+| `GET /vocabulary/vocabularies` | `client.vocabulary.vocabularies()` | `client.vocab.list_vocabularies()` | List all vocabularies |
+| `GET /vocabulary/concept/{id}` | `client.vocabulary.concept(id)` | `client.vocab.get_concept(id)` | Get single concept by ID |
+| `GET /vocabulary/concept/{id}/descendants` | `client.vocabulary.concept_descendants(id)` | `client.vocab.descendants(id)` | Get child concepts |
+| `GET /vocabulary/concept/{id}/related` | `client.vocabulary.concept_related(id)` | `client.vocab.related(id)` | Get related concepts |
+| `POST /vocabulary/search/` | `client.vocabulary.search(query, ...)` | `client.vocab.search(query, ...)` | Search concepts by text |
+| `POST /vocabulary/concepts` | `client.vocabulary.concepts(ids)` | `client.vocab.bulk_get(ids)` | Bulk retrieve concepts |
+| `POST /vocabulary/lookup/identifiers` | `client.vocabulary.lookup_identifiers(...)` | - | Map source codes to concepts |
+
+### 📋 Concept Sets
+
+| WebAPI Endpoint | Predictable Method | Shortcut/Alias | Description |
+|----------------|-------------------|----------------|-------------|
+| `GET /conceptset/` | `client.conceptset()` | `client.concept_sets.list()` | List all concept sets |
+| `GET /conceptset/{id}` | `client.conceptset(id)` | `client.concept_sets.get(id)` | Get concept set by ID |
+| `POST /conceptset/` | `client.conceptset.create(name, expression)` | `client.concept_sets.create(name, expression)` | Create new concept set |
+| `PUT /conceptset/{id}` | `client.conceptset.update(id, concept_set)` | `client.concept_sets.update(concept_set)` | Update concept set |
+| `DELETE /conceptset/{id}` | `client.conceptset.delete(id)` | `client.concept_sets.delete(id)` | Delete concept set |
+| `GET /conceptset/{id}/expression` | `client.conceptset_expression(id)` | `client.concept_sets.expression(id)` | Get concept set expression |
+| `POST /conceptset/{id}/expression` | `client.conceptset_expression.set(id, expr)` | `client.concept_sets.set_expression(id, expr)` | Update expression only |
+| `GET /conceptset/{id}/items` | `client.conceptset_items(id)` | `client.concept_sets.resolve(id)` | Resolve to concrete concepts |
+| `GET /conceptset/{id}/export` | `client.conceptset_export(id, format)` | `client.concept_sets.export(id, format)` | Export as CSV/JSON |
+| `POST /conceptset/compare` | `client.conceptset.compare(id1, id2)` | `client.concept_sets.compare(id1, id2)` | Compare two concept sets |
+| `GET /conceptset/{id}/generationinfo` | `client.conceptset_generationinfo(id)` | `client.concept_sets.generation_info(id)` | Get generation metadata |
+
+### 👥 Cohort Definitions
+
+| WebAPI Endpoint | Predictable Method | Shortcut/Alias | Description |
+|----------------|-------------------|----------------|-------------|
+| `GET /cohortdefinition/` | `client.cohortdefinition()` | `client.cohorts.list()` | List all cohort definitions |
+| `GET /cohortdefinition/{id}` | `client.cohortdefinition(id)` | `client.cohorts.get(id)` | Get cohort definition by ID |
+| `POST /cohortdefinition/` | `client.cohortdefinition.create(cohort_def)` | `client.cohorts.create(cohort_def)` | Create new cohort definition |
+| `PUT /cohortdefinition/{id}` | `client.cohortdefinition.update(id, cohort_def)` | `client.cohorts.update(cohort_def)` | Update cohort definition |
+| `DELETE /cohortdefinition/{id}` | `client.cohortdefinition.delete(id)` | `client.cohorts.delete(id)` | Delete cohort definition |
+| `POST /cohortdefinition/{id}/generate/{source}` | `client.cohortdefinition_generate(id, source_key)` | `client.cohorts.generate(id, source_key)` | Generate cohort on data source |
+| `GET /cohortdefinition/{id}/info` | `client.cohortdefinition_info(id)` | `client.cohorts.generation_status(id, source)` | Check generation status |
+| `GET /cohortdefinition/{id}/inclusionrules/{source}` | `client.cohortdefinition_inclusionrules(id, source)` | `client.cohorts.inclusion_rules(id, source)` | Get inclusion rule statistics |
+
+### ⚙️ Job Management
+
+| WebAPI Endpoint | Predictable Method | Shortcut/Alias | Description |
+|----------------|-------------------|----------------|-------------|
+| `GET /job/{execution_id}` | `client.job(execution_id)` | `client.jobs.get_status(execution_id)` | Get job execution status |
+
+## Usage Examples
+
+### Basic Workflow: Building a Diabetes Cohort
+
+```python
+from ohdsi_webapi import WebApiClient
+
+client = WebApiClient("https://your-webapi-url.com")
+
+# 1. Search for diabetes concepts
+diabetes_concepts = client.vocabulary.search("type 2 diabetes", domain_id="Condition")
+main_concept = diabetes_concepts[0]
+
+# 2. Create a concept set (using predictable naming)
+concept_set_expr = {
+    "items": [{
+        "concept": {"conceptId": main_concept.concept_id},
+        "includeDescendants": True,
+        "isExcluded": False
+    }]
+}
+diabetes_cs = client.conceptset.create("Type 2 Diabetes", concept_set_expr)
+
+# 3. Create cohort definition (simplified)
+cohort_expr = {
+    "PrimaryCriteria": {...},  # Your cohort logic here
+    "ConceptSets": [diabetes_cs.expression]
+}
+cohort = client.cohortdefinition.create({
+    "name": "T2DM Patients", 
+    "expression": cohort_expr
+})
+
+# 4. Generate on a data source
+sources = client.sources.list()
+source_key = sources[0].source_key
+status = client.cohortdefinition_generate(cohort.id, source_key)
+
+# 5. Poll for completion
+final_status = client.cohorts.poll_generation(cohort.id, source_key)  # Helper method
+print(f"Generation {final_status.status}")
+```
+
+### Using Both Predictable and Shortcut Methods
+
+```python
+# These are equivalent - use whichever feels more natural:
+
+# Predictable (matches REST endpoints exactly)
+concept_sets = client.conceptset()  # GET /conceptset/
+diabetes_cs = client.conceptset(123)  # GET /conceptset/123
+expression = client.conceptset_expression(123)  # GET /conceptset/123/expression
+
+cohorts = client.cohortdefinition()  # GET /cohortdefinition/
+my_cohort = client.cohortdefinition(456)  # GET /cohortdefinition/456
+
+# Shortcuts (pythonic, backwards compatible)
+concept_sets = client.concept_sets.list()
+diabetes_cs = client.concept_sets.get(123)
+expression = client.concept_sets.expression(123)
+
+cohorts = client.cohorts.list()
+my_cohort = client.cohorts.get(456)
+```
+
+## Missing Endpoints
+
+If you need an endpoint that's not listed here, please [open an issue](https://github.com/your-org/ohdsi-webapi-client/issues) with:
+- The specific WebAPI endpoint you need
+- Your use case / why you need it
+- Priority (blocking vs. nice-to-have)
+
+We prioritize endpoints based on cohort building workflows, but we're open to expanding coverage based on community needs.
+
+## Endpoint Discovery
+
+To explore what's available in your WebAPI instance:
+
+```python
+# Check WebAPI version and capabilities
+info = client.info.get()
+print(f"WebAPI Version: {info.version}")
+
+# List available data sources
+sources = client.sources.list()
+for source in sources:
+    print(f"Source: {source.source_name} ({source.source_key})")
+
+# List domains and vocabularies
+domains = client.vocabulary.domains()
+vocabularies = client.vocabulary.vocabularies()
+print(f"Available: {len(domains)} domains, {len(vocabularies)} vocabularies")
+```
+
+This gives you a quick overview of what your specific WebAPI instance supports.

--- a/docs/vocabulary_new.md
+++ b/docs/vocabulary_new.md
@@ -1,0 +1,349 @@
+# Vocabulary & Concepts in OHDSI
+
+## What is a Medical Vocabulary?
+
+In healthcare data, different organizations use different coding systems to record the same information. For example, "heart attack" might be coded as:
+- `410.9` in ICD-9
+- `I21.9` in ICD-10  
+- `22298006` in SNOMED CT
+
+A **vocabulary** in OHDSI is simply one of these coding systems. The OMOP Common Data Model brings them all together so you can work with medical concepts consistently across different data sources.
+
+### Common Vocabularies in OMOP
+
+| Vocabulary | What It Covers | Example |
+|------------|----------------|---------|
+| **SNOMED CT** | Clinical findings, conditions, procedures | `201826` = "Type 2 diabetes mellitus" |
+| **RxNorm** | Drugs and medications | `1503297` = "Metformin 500 mg tablet" |
+| **LOINC** | Lab tests and measurements | `4548-4` = "Hemoglobin A1c" |
+| **ICD-10-CM** | Diagnoses (for billing) | `E11.9` = "Type 2 diabetes without complications" |
+| **CPT4** | Medical procedures | `99213` = "Office visit, established patient" |
+
+## Understanding Domains vs Vocabularies
+
+This is a key concept that often confuses newcomers:
+
+### 🏷️ Vocabulary = "Where did this code come from?"
+**Vocabulary** tells you the source coding system:
+- `SNOMED` - from SNOMED CT
+- `RxNorm` - from RxNorm  
+- `ICD10CM` - from ICD-10-CM
+
+### 📁 Domain = "What type of medical concept is this?"
+**Domain** tells you the category for analysis purposes:
+- `Condition` - diseases, symptoms, clinical findings
+- `Drug` - medications and drug products
+- `Procedure` - medical interventions
+- `Measurement` - lab tests, vital signs
+- `Observation` - other clinical observations
+
+### Example: Same Concept, Different Perspectives
+
+```
+Concept ID: 201826
+Concept Name: "Type 2 diabetes mellitus"
+Vocabulary: SNOMED    ← "This code comes from SNOMED CT"
+Domain: Condition     ← "This belongs in the Condition table for analysis"
+```
+
+**Why this matters**: When building cohorts, you search by **domain** ("show me all conditions") but the results might come from multiple **vocabularies** (SNOMED, ICD-10, etc.).
+
+## OMOP Database Structure
+
+The vocabulary data lives in these key tables:
+
+| Table | What It Contains |
+|-------|------------------|
+| `VOCABULARY` | List of all coding systems (SNOMED, RxNorm, etc.) |
+| `CONCEPT` | All medical concepts from all vocabularies |
+| `CONCEPT_RELATIONSHIP` | How concepts relate to each other |
+| `CONCEPT_ANCESTOR` | Parent/child hierarchies (e.g., "diabetes" → "type 2 diabetes") |
+
+## Working with the Vocabulary API
+
+### Setup
+
+```python
+from ohdsi_webapi import WebApiClient
+
+client = WebApiClient("https://your-webapi-url.com")
+# The vocabulary service is available as both:
+# client.vocabulary (full name) or client.vocab (shorter alias)
+```
+
+### 1. Looking Up a Specific Concept
+
+If you know the concept ID:
+
+```python
+# Get a specific concept by ID
+concept = client.vocab.get_concept(201826)  # Type 2 diabetes
+
+print(f"Name: {concept.concept_name}")
+print(f"Domain: {concept.domain_id}")  
+print(f"Vocabulary: {concept.vocabulary_id}")
+print(f"Standard: {concept.standard_concept}")
+```
+
+### 2. Searching for Concepts by Text
+
+This is usually how you start - you know what you're looking for but need the concept ID:
+
+```python
+# Search for diabetes-related concepts
+results = client.vocab.search(
+    query="diabetes",
+    domain_id="Condition",        # Only conditions
+    standard_concept="S",         # Only standard concepts
+    page_size=20
+)
+
+for concept in results:
+    print(f"{concept.concept_id}: {concept.concept_name}")
+```
+
+**Search Parameters:**
+- `query` - Text to search for in concept names
+- `domain_id` - Filter by domain ("Condition", "Drug", "Procedure", etc.)
+- `vocabulary_id` - Filter by vocabulary ("SNOMED", "RxNorm", etc.)
+- `concept_class_id` - Filter by concept class ("Clinical Finding", "Ingredient", etc.)
+- `standard_concept` - "S" for standard concepts (recommended for analysis)
+
+### 3. Working with Concept Hierarchies
+
+Medical concepts are organized in hierarchies. For example:
+- Diabetes (parent)
+  - Type 1 diabetes (child)
+  - Type 2 diabetes (child)
+
+```python
+# Get all child concepts (more specific)
+children = client.vocab.descendants(201826)  # All types of diabetes
+print(f"Found {len(children)} more specific diabetes concepts")
+
+# Get all parent concepts (more general)  
+parents = client.vocab.ancestors(201826)  # Broader categories
+print(f"Found {len(parents)} broader categories")
+```
+
+**When to use hierarchies:**
+- **Descendants**: When you want to be inclusive (e.g., find all types of diabetes)
+- **Ancestors**: When you want to group concepts into broader categories
+
+### 4. Bulk Operations
+
+When you have multiple concept IDs, batch them for better performance:
+
+```python
+concept_ids = [201826, 1503297, 4548-4]  # diabetes, metformin, A1c
+concepts = client.vocab.bulk_get(concept_ids)
+
+for concept in concepts:
+    print(f"{concept.concept_id}: {concept.concept_name} ({concept.domain_id})")
+```
+
+### 5. Converting Source Codes to OMOP Concepts
+
+When you have codes from other systems (like ICD-10 or NDC codes), you need to map them to OMOP concepts:
+
+```python
+# Look up codes from other systems
+lookup_results = client.vocab.lookup_identifiers([
+    {"identifier": "E11.9", "vocabularyId": "ICD10CM"},  # ICD-10 code
+    {"identifier": "50096", "vocabularyId": "NDC"},      # NDC drug code
+])
+
+for result in lookup_results:
+    if result.standard_concept == "S":
+        print(f"Standard concept: {result.concept_id} - {result.concept_name}")
+```
+
+### 6. Exploring Available Domains
+
+To see what types of medical data are available:
+
+```python
+domains = client.vocab.list_domains()
+for domain in domains:
+    print(f"{domain['domainId']}: {domain['domainName']}")
+```
+
+## Standard vs Non-Standard Concepts
+
+This is crucial for analysis:
+
+### ✅ Standard Concepts (`standard_concept = "S"`)
+- **Use these for analysis and cohort building**
+- Consistent across all OMOP databases
+- One "best" concept per medical entity
+- Example: SNOMED concept for "Type 2 diabetes"
+
+### ❌ Non-Standard Concepts
+- Original source codes (ICD-10, local hospital codes, etc.)  
+- **Don't use these for analysis**
+- Map to standard concepts instead
+- Example: ICD-10 code `E11.9` maps to SNOMED `201826`
+
+```python
+# Always filter to standard concepts for analysis
+standard_diabetes = client.vocab.search(
+    query="diabetes",
+    standard_concept="S",  # This is key!
+    domain_id="Condition"
+)
+```
+
+## Practical Examples
+
+### Example 1: Building a Diabetes Cohort
+
+```python
+# 1. Search for diabetes concepts
+diabetes_concepts = client.vocab.search(
+    query="type 2 diabetes",
+    domain_id="Condition", 
+    standard_concept="S"
+)
+
+# 2. Pick the main concept
+main_diabetes = diabetes_concepts[0]  # Usually the first result
+print(f"Using: {main_diabetes.concept_id} - {main_diabetes.concept_name}")
+
+# 3. Get all related diabetes concepts (more inclusive)
+all_diabetes = client.vocab.descendants(main_diabetes.concept_id)
+print(f"Including {len(all_diabetes)} related concepts")
+```
+
+### Example 2: Finding Medications
+
+```python
+# Search for metformin (diabetes medication)
+metformin_drugs = client.vocab.search(
+    query="metformin",
+    domain_id="Drug",
+    standard_concept="S"
+)
+
+for drug in metformin_drugs[:5]:  # Show first 5
+    print(f"{drug.concept_id}: {drug.concept_name}")
+    print(f"  Class: {drug.concept_class_id}")
+```
+
+### Example 3: Lab Tests and Measurements
+
+```python
+# Find A1C lab test (diabetes monitoring)
+a1c_tests = client.vocab.search(
+    query="hemoglobin a1c",
+    domain_id="Measurement",
+    standard_concept="S"
+)
+
+for test in a1c_tests:
+    print(f"{test.concept_id}: {test.concept_name}")
+```
+
+## Best Practices
+
+### 1. Always Use Standard Concepts for Analysis
+```python
+# ✅ Good - filters to standard concepts
+results = client.vocab.search("diabetes", standard_concept="S")
+
+# ❌ Avoid - includes non-standard concepts
+results = client.vocab.search("diabetes")  # No filter
+```
+
+### 2. Batch API Calls When Possible
+```python
+# ✅ Good - single API call
+concepts = client.vocab.bulk_get([201826, 1503297, 4548])
+
+# ❌ Inefficient - multiple API calls
+concepts = []
+for concept_id in [201826, 1503297, 4548]:
+    concepts.append(client.vocab.get_concept(concept_id))
+```
+
+### 3. Use Hierarchies Appropriately
+```python
+# For inclusive cohorts (recommended)
+diabetes_concept_id = 201826
+all_diabetes_types = client.vocab.descendants(diabetes_concept_id)
+
+# Use all descendants in your cohort definition
+concept_set = {
+    "id": 0,
+    "name": "All Diabetes Types", 
+    "expression": {
+        "items": [{"concept": {"conceptId": diabetes_concept_id, "includeDescendants": True}}]
+    }
+}
+```
+
+## Common Workflows
+
+### Building a Concept Set for Research
+
+1. **Search** for your concept of interest
+2. **Review** the results and pick the most appropriate standard concept
+3. **Check descendants** to see if you want to include more specific concepts
+4. **Validate** by looking at the concept names and classifications
+
+```python
+# Complete workflow example
+def build_diabetes_concept_set():
+    # Step 1: Search
+    results = client.vocab.search("type 2 diabetes", domain_id="Condition", standard_concept="S")
+    
+    # Step 2: Review and select
+    main_concept = results[0]  # Assume first is best match
+    print(f"Selected: {main_concept.concept_name}")
+    
+    # Step 3: Check descendants
+    descendants = client.vocab.descendants(main_concept.concept_id)
+    print(f"This will include {len(descendants)} related concepts")
+    
+    # Step 4: Create concept set definition
+    concept_set = {
+        "id": 0,
+        "name": "Type 2 Diabetes",
+        "expression": {
+            "items": [{
+                "concept": {
+                    "conceptId": main_concept.concept_id,
+                    "includeDescendants": True  # Include all subtypes
+                }
+            }]
+        }
+    }
+    
+    return concept_set
+```
+
+## Error Handling
+
+```python
+from ohdsi_webapi.exceptions import WebApiError
+
+try:
+    concept = client.vocab.get_concept(999999999)  # Invalid ID
+except WebApiError as e:
+    print(f"API Error: {e.status_code} - {e.message}")
+    # Handle gracefully - maybe use a default concept or ask user to try again
+```
+
+## Performance Tips
+
+1. **Cache frequently used concepts** in your application
+2. **Use bulk operations** when fetching multiple concepts
+3. **Apply filters early** to reduce result set sizes
+4. **Reuse search results** instead of re-searching
+
+## Next Steps
+
+- **[Concept Sets](concept_sets.md)**: Learn how to group concepts for analysis
+- **[Cohorts](cohorts.md)**: Use concepts to define patient populations  
+- **[Caching](caching.md)**: Optimize performance for repeated API calls
+
+Need help? The OHDSI community is very welcoming to newcomers. Check out the [OHDSI Forums](https://forums.ohdsi.org/) for questions and discussions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ohdsi-webapi-client"
-version = "0.1.0-alpha"
+version = "0.2.0-alpha"
 description = "Python client for OHDSI WebAPI (MVP: info, sources, vocabulary, concept sets, cohorts)."
 authors = ["Your Name <you@example.com>"]
 license = "Apache-2.0"

--- a/src/ohdsi_webapi/client.py
+++ b/src/ohdsi_webapi/client.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from .auth import AuthStrategy
 from .cache import cache_stats, clear_cache
 from .http import HttpExecutor
@@ -11,20 +13,113 @@ from .services.sources import SourcesService
 from .services.vocabulary import VocabularyService
 
 
+class PredictableServiceWrapper:
+    """Wrapper that makes a service callable to match REST endpoint patterns."""
+
+    def __init__(self, service: Any):
+        self._service = service
+
+    def __call__(self, resource_id: int | None = None, *args, **kwargs):
+        """Handle calls like conceptset() and conceptset(123)."""
+        if resource_id is None:
+            # GET /conceptset/ -> list()
+            return self._service.list(*args, **kwargs)
+        else:
+            # GET /conceptset/{id} -> get(id)
+            return self._service.get(resource_id, *args, **kwargs)
+
+    def __getattr__(self, name: str):
+        """Delegate all other attribute access to the wrapped service."""
+        return getattr(self._service, name)
+
+
+class PredictableInfoWrapper:
+    """Wrapper that makes info service callable as info()."""
+
+    def __init__(self, service: Any):
+        self._service = service
+
+    def __call__(self, *args, **kwargs):
+        """Handle calls like info()."""
+        return self._service.get(*args, **kwargs)
+
+    def __getattr__(self, name: str):
+        """Delegate all other attribute access to the wrapped service."""
+        return getattr(self._service, name)
+
+
 class WebApiClient:
     def __init__(self, base_url: str, *, auth: AuthStrategy | None = None, timeout: float = 30.0, verify: bool | str = True):
         self._http = HttpExecutor(
             base_url.rstrip("/"), timeout=timeout, auth_headers_cb=(auth.auth_headers if auth else None), verify=verify
         )
-        self.info = InfoService(self._http)
+        self._info_service = InfoService(self._http)
+        self.info = PredictableInfoWrapper(self._info_service)  # Callable for REST pattern
         self.sources = SourcesService(self._http)
         self.vocabulary = VocabularyService(self._http)  # Naming consistent with WebAPI path (/vocabulary/)
         self.vocab = self.vocabulary  # Alias for convenience
         self.concept_sets = ConceptSetService(self._http)
-        self.conceptset = self.concept_sets  # Alias for WebAPI path consistency (/conceptset/)
+        self.conceptset = PredictableServiceWrapper(self.concept_sets)  # Callable for REST pattern
         self.cohorts = CohortService(self._http)
-        self.cohortdefinition = self.cohorts  # Alias for WebAPI path consistency (/cohortdefinition/)
-        self.jobs = JobsService(self._http)
+        self.cohortdefinition = PredictableServiceWrapper(self.cohorts)  # Callable for REST pattern
+        self._jobs_service = JobsService(self._http)
+        self.jobs = self._jobs_service  # Backwards compatibility
+
+    def __getattr__(self, name: str) -> Any:
+        """Handle predictable method calls that mirror REST endpoints.
+
+        This enables calls like:
+        - client.conceptset_expression(123) -> GET /conceptset/123/expression
+        - client.cohortdefinition_generate(123, source) -> POST /cohortdefinition/123/generate/source
+        - client.source_sources() -> GET /source/sources
+        - client.job(execution_id) -> GET /job/{execution_id}
+        """
+        # Handle conceptset_* predictable methods
+        if name.startswith("conceptset_"):
+            sub_resource = name[11:]  # Remove "conceptset_" prefix
+            return self._create_conceptset_sub_method(sub_resource)
+
+        # Handle cohortdefinition_* predictable methods
+        elif name.startswith("cohortdefinition_"):
+            sub_resource = name[17:]  # Remove "cohortdefinition_" prefix
+            return self._create_cohortdefinition_sub_method(sub_resource)
+
+        # Handle source_sources() -> GET /source/sources
+        elif name == "source_sources":
+            return lambda: self.sources.list()
+
+        # Handle job(execution_id) -> GET /job/{execution_id}
+        elif name == "job":
+            return lambda execution_id: self._jobs_service.status(execution_id)
+
+        # If not a predictable method, raise AttributeError
+        raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{name}'")
+
+    def _create_conceptset_sub_method(self, sub_resource: str):
+        """Create methods for conceptset sub-resources like conceptset_expression(id)."""
+        if sub_resource == "expression":
+            return lambda concept_set_id: self.concept_sets.expression(concept_set_id)
+        elif sub_resource == "items":
+            return lambda concept_set_id: self.concept_sets.resolve(concept_set_id)
+        elif sub_resource == "export":
+            return lambda concept_set_id, format="csv": self.concept_sets.export(concept_set_id, format)
+        elif sub_resource == "generationinfo":
+            return lambda concept_set_id: self.concept_sets.generation_info(concept_set_id)
+        else:
+            raise AttributeError(f"Unknown conceptset sub-resource: {sub_resource}")
+
+    def _create_cohortdefinition_sub_method(self, sub_resource: str):
+        """Create methods for cohortdefinition sub-resources like cohortdefinition_generate(id, source)."""
+        if sub_resource == "generate":
+            return lambda cohort_id, source_key: self.cohorts.generate(cohort_id, source_key)
+        elif sub_resource == "info":
+            return lambda cohort_id, source_key=None: (
+                self.cohorts.generation_status(cohort_id, source_key) if source_key else self.cohorts.get(cohort_id)
+            )
+        elif sub_resource == "inclusionrules":
+            return lambda cohort_id, source_key: self.cohorts.inclusion_rules(cohort_id, source_key)
+        else:
+            raise AttributeError(f"Unknown cohortdefinition sub-resource: {sub_resource}")
 
     def close(self):
         self._http.close()

--- a/tests/unit/test_predictable_api.py
+++ b/tests/unit/test_predictable_api.py
@@ -1,0 +1,148 @@
+"""Tests for predictable API naming patterns that mirror REST endpoints."""
+
+import pytest
+from ohdsi_webapi import WebApiClient
+
+
+class TestPredictableAPI:
+    """Test the predictable API naming convention."""
+
+    @pytest.fixture()
+    def client(self):
+        """Create a test client."""
+        return WebApiClient("https://test.example.com")
+
+    def test_conceptset_callable_interface(self, client):
+        """Test that conceptset is callable for REST-style access."""
+        # Should be callable
+        assert callable(client.conceptset)
+
+        # Should delegate to underlying service methods
+        assert hasattr(client.conceptset, "list")
+        assert hasattr(client.conceptset, "get")
+        assert hasattr(client.conceptset, "create")
+        assert hasattr(client.conceptset, "update")
+        assert hasattr(client.conceptset, "delete")
+
+    def test_cohortdefinition_callable_interface(self, client):
+        """Test that cohortdefinition is callable for REST-style access."""
+        # Should be callable
+        assert callable(client.cohortdefinition)
+
+        # Should delegate to underlying service methods
+        assert hasattr(client.cohortdefinition, "list")
+        assert hasattr(client.cohortdefinition, "get")
+        assert hasattr(client.cohortdefinition, "create")
+        assert hasattr(client.cohortdefinition, "update")
+        assert hasattr(client.cohortdefinition, "delete")
+
+    def test_conceptset_subresource_methods(self, client):
+        """Test that conceptset sub-resource methods are dynamically available."""
+        # These should be available via __getattr__
+        assert hasattr(client, "conceptset_expression")
+        assert hasattr(client, "conceptset_items")
+        assert hasattr(client, "conceptset_export")
+        assert hasattr(client, "conceptset_generationinfo")
+
+        # Should be callable
+        assert callable(client.conceptset_expression)
+        assert callable(client.conceptset_items)
+        assert callable(client.conceptset_export)
+        assert callable(client.conceptset_generationinfo)
+
+    def test_cohortdefinition_subresource_methods(self, client):
+        """Test that cohortdefinition sub-resource methods are dynamically available."""
+        # These should be available via __getattr__
+        assert hasattr(client, "cohortdefinition_generate")
+        assert hasattr(client, "cohortdefinition_info")
+        assert hasattr(client, "cohortdefinition_inclusionrules")
+
+        # Should be callable
+        assert callable(client.cohortdefinition_generate)
+        assert callable(client.cohortdefinition_info)
+        assert callable(client.cohortdefinition_inclusionrules)
+
+    def test_info_callable_interface(self, client):
+        """Test that info is callable for REST-style access."""
+        # Should be callable
+        assert callable(client.info)
+
+        # Should delegate to underlying service methods
+        assert hasattr(client.info, "get")
+        assert hasattr(client.info, "version")
+
+    def test_source_sources_predictable_method(self, client):
+        """Test that source_sources method is available."""
+        # Should be available via __getattr__
+        assert hasattr(client, "source_sources")
+
+        # Should be callable
+        assert callable(client.source_sources)
+
+    def test_job_predictable_method(self, client):
+        """Test that job method is available."""
+        # Should be available via __getattr__
+        assert hasattr(client, "job")
+
+        # Should be callable
+        assert callable(client.job)
+
+    def test_backwards_compatibility(self, client):
+        """Test that existing service-based API still works."""
+        # Original service attributes should exist
+        assert hasattr(client, "concept_sets")
+        assert hasattr(client, "cohorts")
+        assert hasattr(client, "vocabulary")
+        assert hasattr(client, "vocab")
+
+        # Original methods should be callable
+        assert callable(client.concept_sets.list)
+        assert callable(client.concept_sets.get)
+        assert callable(client.cohorts.list)
+        assert callable(client.cohorts.get)
+        assert callable(client.vocabulary.search)
+
+    def test_vocabulary_predictable_methods(self, client):
+        """Test that vocabulary service has predictable methods."""
+        # Vocabulary should support both full name and alias
+        assert hasattr(client, "vocabulary")
+        assert hasattr(client, "vocab")
+        assert client.vocab is client.vocabulary
+
+        # Should have predictable method names
+        assert hasattr(client.vocabulary, "concept_descendants")
+        assert hasattr(client.vocabulary, "concept_related")
+        assert hasattr(client.vocabulary, "concepts")
+        assert hasattr(client.vocabulary, "vocabularies")
+        assert hasattr(client.vocabulary, "domains")
+
+    def test_unknown_subresource_raises_error(self, client):
+        """Test that unknown sub-resource methods raise appropriate errors."""
+        with pytest.raises(AttributeError, match="Unknown conceptset sub-resource"):
+            _ = client.conceptset_unknown_method
+
+        with pytest.raises(AttributeError, match="Unknown cohortdefinition sub-resource"):
+            _ = client.cohortdefinition_unknown_method
+
+    def test_unknown_attribute_raises_error(self, client):
+        """Test that completely unknown attributes raise AttributeError."""
+        with pytest.raises(AttributeError, match="object has no attribute"):
+            _ = client.completely_unknown_attribute
+
+    def test_predictable_wrapper_delegation(self, client):
+        """Test that PredictableServiceWrapper properly delegates attributes."""
+        # Wrapper should delegate all service methods
+        wrapper = client.conceptset
+
+        # Check that delegation works for common methods
+        assert hasattr(wrapper, "list")
+        assert hasattr(wrapper, "get")
+        assert hasattr(wrapper, "create")
+
+        # The delegated methods should be callable and equivalent
+        assert callable(wrapper.list)
+        assert callable(wrapper.get)
+        assert callable(wrapper.create)
+
+        # Wrapper should be callable itself
+        assert callable(wrapper)


### PR DESCRIPTION
- Add PredictableServiceWrapper and PredictableInfoWrapper for callable services
- Implement client.info(), client.source_sources(), and client.job(execution_id) methods
- Add dynamic method dispatch for conceptset_* and cohortdefinition_* sub-resources
- Create comprehensive supported_endpoints.md documentation
- Add extensive test coverage for predictable API patterns
- Maintain full backwards compatibility with existing service methods
- Version bump to 0.2.0-alpha for new feature set

This makes the API self-documenting and intuitive for engineers new to OHDSI/OMOP by ensuring Python method names directly mirror WebAPI REST endpoint paths.