### PR TITLE
refactor: simplify WebApiClient to use explicit method assignments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ohdsi-webapi-client"
-version = "0.3.1"
+version = "0.4.0"
 description = "Python client for OHDSI WebAPI (MVP: info, sources, vocabulary, concept sets, cohorts)."
 authors = ["Your Name <you@example.com>"]
 license = "Apache-2.0"

--- a/src/ohdsi_webapi/__init__.py
+++ b/src/ohdsi_webapi/__init__.py
@@ -7,5 +7,3 @@ from .env import load_env
 load_env()
 
 __all__ = ["WebApiClient"]
-
-__version__ = "0.1.0"

--- a/src/ohdsi_webapi/client.py
+++ b/src/ohdsi_webapi/client.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Any
-
 from .auth import AuthStrategy
 from .cache import cache_stats, clear_cache
 from .http import HttpExecutor
@@ -13,109 +11,35 @@ from .services.sources import SourcesService
 from .services.vocabulary import VocabularyService
 
 
-class PredictableServiceWrapper:
-    """Wrapper that makes a service callable to match REST endpoint patterns."""
-
-    def __init__(self, service: Any):
-        self._service = service
-
-    def __call__(self, resource_id: int | None = None, *args, **kwargs):
-        """Handle calls like conceptset() and conceptset(123)."""
-        if resource_id is None:
-            # GET /conceptset/ -> list()
-            return self._service.list(*args, **kwargs)
-        else:
-            # GET /conceptset/{id} -> get(id)
-            return self._service.get(resource_id, *args, **kwargs)
-
-    def __getattr__(self, name: str):
-        """Delegate all other attribute access to the wrapped service."""
-        return getattr(self._service, name)
-
-
-class PredictableInfoWrapper:
-    """Wrapper that makes info service callable as info()."""
-
-    def __init__(self, service: Any):
-        self._service = service
-
-    def __call__(self, *args, **kwargs):
-        """Handle calls like info()."""
-        return self._service.get(*args, **kwargs)
-
-    def __getattr__(self, name: str):
-        """Delegate all other attribute access to the wrapped service."""
-        return getattr(self._service, name)
-
-
 class WebApiClient:
     def __init__(self, base_url: str, *, auth: AuthStrategy | None = None, timeout: float = 30.0, verify: bool | str = True):
         self._http = HttpExecutor(
             base_url.rstrip("/"), timeout=timeout, auth_headers_cb=(auth.auth_headers if auth else None), verify=verify
         )
-        self._info_service = InfoService(self._http)
-        self.info = PredictableInfoWrapper(self._info_service)  # Callable for REST pattern
-        self._sources_service = SourcesService(self._http)
-        self.sources = PredictableServiceWrapper(self._sources_service)  # Callable for REST pattern
-        self.vocabulary = VocabularyService(self._http)  # Naming consistent with WebAPI path (/vocabulary/)
+
+        # Core service objects (primary interface)
+        self.info = InfoService(self._http)
+        self.sources = SourcesService(self._http)
+        self.vocabulary = VocabularyService(self._http)
         self.vocab = self.vocabulary  # Alias for convenience
         self.concept_sets = ConceptSetService(self._http)
-        self.conceptset = PredictableServiceWrapper(self.concept_sets)  # Callable for REST pattern
         self.cohorts = CohortService(self._http)
-        self.cohortdefinition = PredictableServiceWrapper(self.cohorts)  # Callable for REST pattern
-        self._jobs_service = JobsService(self._http)
-        self.jobs = self._jobs_service  # Backwards compatibility
+        self.jobs = JobsService(self._http)
 
-    def __getattr__(self, name: str) -> Any:
-        """Handle predictable method calls that mirror REST endpoints.
+        # Explicit REST-style convenience methods
+        # Concept set methods
+        self.conceptset_expression = self.concept_sets.expression
+        self.conceptset_items = self.concept_sets.resolve
+        self.conceptset_export = self.concept_sets.export
+        self.conceptset_generationinfo = self.concept_sets.generation_info
 
-        This enables calls like:
-        - client.conceptset_expression(123) -> GET /conceptset/123/expression
-        - client.cohortdefinition_generate(123, source) -> POST /cohortdefinition/123/generate/source
-        - client.job(execution_id) -> GET /job/{execution_id}
-        """
-        # Handle conceptset_* predictable methods
-        if name.startswith("conceptset_"):
-            sub_resource = name[11:]  # Remove "conceptset_" prefix
-            return self._create_conceptset_sub_method(sub_resource)
+        # Cohort definition methods
+        self.cohortdefinition_generate = self.cohorts.generate
+        self.cohortdefinition_info = self.cohorts.generation_status
+        self.cohortdefinition_inclusionrules = self.cohorts.inclusion_rules
 
-        # Handle cohortdefinition_* predictable methods
-        elif name.startswith("cohortdefinition_"):
-            sub_resource = name[17:]  # Remove "cohortdefinition_" prefix
-            return self._create_cohortdefinition_sub_method(sub_resource)
-
-        # Handle job(execution_id) -> GET /job/{execution_id}
-        elif name == "job":
-            return lambda execution_id: self._jobs_service.status(execution_id)
-
-        # If not a predictable method, raise AttributeError
-        raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{name}'")
-
-    def _create_conceptset_sub_method(self, sub_resource: str):
-        """Create methods for conceptset sub-resources like conceptset_expression(id)."""
-        if sub_resource == "expression":
-            return lambda concept_set_id: self.concept_sets.expression(concept_set_id)
-        elif sub_resource == "items":
-            return lambda concept_set_id: self.concept_sets.resolve(concept_set_id)
-        elif sub_resource == "export":
-            return lambda concept_set_id, format="csv": self.concept_sets.export(concept_set_id, format)
-        elif sub_resource == "generationinfo":
-            return lambda concept_set_id: self.concept_sets.generation_info(concept_set_id)
-        else:
-            raise AttributeError(f"Unknown conceptset sub-resource: {sub_resource}")
-
-    def _create_cohortdefinition_sub_method(self, sub_resource: str):
-        """Create methods for cohortdefinition sub-resources like cohortdefinition_generate(id, source)."""
-        if sub_resource == "generate":
-            return lambda cohort_id, source_key: self.cohorts.generate(cohort_id, source_key)
-        elif sub_resource == "info":
-            return lambda cohort_id, source_key=None: (
-                self.cohorts.generation_status(cohort_id, source_key) if source_key else self.cohorts.get(cohort_id)
-            )
-        elif sub_resource == "inclusionrules":
-            return lambda cohort_id, source_key: self.cohorts.inclusion_rules(cohort_id, source_key)
-        else:
-            raise AttributeError(f"Unknown cohortdefinition sub-resource: {sub_resource}")
+        # Job methods
+        self.job_status = self.jobs.status
 
     def close(self):
         self._http.close()

--- a/tests/unit/test_predictable_api.py
+++ b/tests/unit/test_predictable_api.py
@@ -1,44 +1,46 @@
-"""Tests for predictable API naming patterns that mirror REST endpoints."""
+"""Tests for explicit REST-style convenience methods and service interfaces."""
 
 import pytest
 from ohdsi_webapi import WebApiClient
 
 
-class TestPredictableAPI:
-    """Test the predictable API naming convention."""
+class TestExplicitAPI:
+    """Test the explicit API methods and service interfaces."""
 
     @pytest.fixture()
     def client(self):
         """Create a test client."""
         return WebApiClient("https://test.example.com")
 
-    def test_conceptset_callable_interface(self, client):
-        """Test that conceptset is callable for REST-style access."""
-        # Should be callable
-        assert callable(client.conceptset)
+    def test_core_service_interfaces(self, client):
+        """Test that core service objects are available."""
+        # Core services should exist
+        assert hasattr(client, "concept_sets")
+        assert hasattr(client, "cohorts")
+        assert hasattr(client, "vocabulary")
+        assert hasattr(client, "vocab")
+        assert hasattr(client, "info")
+        assert hasattr(client, "sources")
+        assert hasattr(client, "jobs")
 
-        # Should delegate to underlying service methods
-        assert hasattr(client.conceptset, "list")
-        assert hasattr(client.conceptset, "get")
-        assert hasattr(client.conceptset, "create")
-        assert hasattr(client.conceptset, "update")
-        assert hasattr(client.conceptset, "delete")
+        # Vocabulary alias should work
+        assert client.vocab is client.vocabulary
 
-    def test_cohortdefinition_callable_interface(self, client):
-        """Test that cohortdefinition is callable for REST-style access."""
-        # Should be callable
-        assert callable(client.cohortdefinition)
+        # Services should have their standard methods
+        assert hasattr(client.concept_sets, "list")
+        assert hasattr(client.concept_sets, "get")
+        assert hasattr(client.concept_sets, "create")
+        assert hasattr(client.concept_sets, "expression")
+        assert hasattr(client.concept_sets, "resolve")
 
-        # Should delegate to underlying service methods
-        assert hasattr(client.cohortdefinition, "list")
-        assert hasattr(client.cohortdefinition, "get")
-        assert hasattr(client.cohortdefinition, "create")
-        assert hasattr(client.cohortdefinition, "update")
-        assert hasattr(client.cohortdefinition, "delete")
+        assert hasattr(client.cohorts, "list")
+        assert hasattr(client.cohorts, "get")
+        assert hasattr(client.cohorts, "generate")
+        assert hasattr(client.cohorts, "generation_status")
 
-    def test_conceptset_subresource_methods(self, client):
-        """Test that conceptset sub-resource methods are dynamically available."""
-        # These should be available via __getattr__
+    def test_conceptset_convenience_methods(self, client):
+        """Test that conceptset convenience methods are explicitly available."""
+        # These should be explicit attributes (not dynamic)
         assert hasattr(client, "conceptset_expression")
         assert hasattr(client, "conceptset_items")
         assert hasattr(client, "conceptset_export")
@@ -50,9 +52,15 @@ class TestPredictableAPI:
         assert callable(client.conceptset_export)
         assert callable(client.conceptset_generationinfo)
 
-    def test_cohortdefinition_subresource_methods(self, client):
-        """Test that cohortdefinition sub-resource methods are dynamically available."""
-        # These should be available via __getattr__
+        # Should be the same as the service methods
+        assert client.conceptset_expression == client.concept_sets.expression
+        assert client.conceptset_items == client.concept_sets.resolve
+        assert client.conceptset_export == client.concept_sets.export
+        assert client.conceptset_generationinfo == client.concept_sets.generation_info
+
+    def test_cohortdefinition_convenience_methods(self, client):
+        """Test that cohortdefinition convenience methods are explicitly available."""
+        # These should be explicit attributes (not dynamic)
         assert hasattr(client, "cohortdefinition_generate")
         assert hasattr(client, "cohortdefinition_info")
         assert hasattr(client, "cohortdefinition_inclusionrules")
@@ -62,88 +70,73 @@ class TestPredictableAPI:
         assert callable(client.cohortdefinition_info)
         assert callable(client.cohortdefinition_inclusionrules)
 
-    def test_info_callable_interface(self, client):
-        """Test that info is callable for REST-style access."""
-        # Should be callable
-        assert callable(client.info)
+        # Should be the same as the service methods
+        assert client.cohortdefinition_generate == client.cohorts.generate
+        assert client.cohortdefinition_info == client.cohorts.generation_status
+        assert client.cohortdefinition_inclusionrules == client.cohorts.inclusion_rules
 
-        # Should delegate to underlying service methods
-        assert hasattr(client.info, "get")
-        assert hasattr(client.info, "version")
+    def test_job_convenience_methods(self, client):
+        """Test that job convenience methods are available."""
+        # Should have explicit job status method
+        assert hasattr(client, "job_status")
+        assert callable(client.job_status)
+        assert client.job_status == client.jobs.status
 
-    def test_sources_callable_interface(self, client):
-        """Test that sources is callable for REST-style access."""
-        # Should be callable
-        assert callable(client.sources)
-
-        # Should delegate to underlying service methods
-        assert hasattr(client.sources, "list")
-        assert hasattr(client.sources, "iter")
-
-    def test_job_predictable_method(self, client):
-        """Test that job method is available."""
-        # Should be available via __getattr__
-        assert hasattr(client, "job")
-
-        # Should be callable
-        assert callable(client.job)
-
-    def test_backwards_compatibility(self, client):
-        """Test that existing service-based API still works."""
-        # Original service attributes should exist
-        assert hasattr(client, "concept_sets")
-        assert hasattr(client, "cohorts")
-        assert hasattr(client, "vocabulary")
-        assert hasattr(client, "vocab")
-
-        # Original methods should be callable
+    def test_service_method_compatibility(self, client):
+        """Test that service-based API still works as primary interface."""
+        # Original service methods should be callable
         assert callable(client.concept_sets.list)
         assert callable(client.concept_sets.get)
         assert callable(client.cohorts.list)
         assert callable(client.cohorts.get)
         assert callable(client.vocabulary.search)
+        assert callable(client.info.get)
+        assert callable(client.sources.list)
 
-    def test_vocabulary_predictable_methods(self, client):
-        """Test that vocabulary service has predictable methods."""
-        # Vocabulary should support both full name and alias
-        assert hasattr(client, "vocabulary")
-        assert hasattr(client, "vocab")
-        assert client.vocab is client.vocabulary
-
-        # Should have predictable method names
+    def test_vocabulary_methods(self, client):
+        """Test that vocabulary service has expected methods."""
+        # Should have standard vocabulary methods
         assert hasattr(client.vocabulary, "concept_descendants")
         assert hasattr(client.vocabulary, "concept_related")
-        assert hasattr(client.vocabulary, "concepts")
-        assert hasattr(client.vocabulary, "vocabularies")
-        assert hasattr(client.vocabulary, "domains")
+        assert hasattr(client.vocabulary, "search")
+        assert hasattr(client.vocabulary, "list_vocabularies")
+        assert hasattr(client.vocabulary, "list_domains")
 
-    def test_unknown_subresource_raises_error(self, client):
-        """Test that unknown sub-resource methods raise appropriate errors."""
-        with pytest.raises(AttributeError, match="Unknown conceptset sub-resource"):
-            _ = client.conceptset_unknown_method
-
-        with pytest.raises(AttributeError, match="Unknown cohortdefinition sub-resource"):
-            _ = client.cohortdefinition_unknown_method
+        # Methods should be callable
+        assert callable(client.vocabulary.search)
+        assert callable(client.vocabulary.concept_descendants)
 
     def test_unknown_attribute_raises_error(self, client):
-        """Test that completely unknown attributes raise AttributeError."""
-        with pytest.raises(AttributeError, match="object has no attribute"):
+        """Test that unknown attributes raise AttributeError."""
+        with pytest.raises(AttributeError):
             _ = client.completely_unknown_attribute
 
-    def test_predictable_wrapper_delegation(self, client):
-        """Test that PredictableServiceWrapper properly delegates attributes."""
-        # Wrapper should delegate all service methods
-        wrapper = client.conceptset
+        with pytest.raises(AttributeError):
+            _ = client.unknown_convenience_method
 
-        # Check that delegation works for common methods
-        assert hasattr(wrapper, "list")
-        assert hasattr(wrapper, "get")
-        assert hasattr(wrapper, "create")
+    def test_no_dynamic_method_generation(self, client):
+        """Test that we don't have dynamic method generation anymore."""
+        # These should NOT exist (we removed the dynamic __getattr__ magic)
+        assert not hasattr(client, "conceptset_unknown_method")
+        assert not hasattr(client, "cohortdefinition_unknown_method")
 
-        # The delegated methods should be callable and equivalent
-        assert callable(wrapper.list)
-        assert callable(wrapper.get)
-        assert callable(wrapper.create)
+        # No callable wrappers anymore
+        assert not callable(getattr(client, "conceptset", None))
+        assert not callable(getattr(client, "cohortdefinition", None))
 
-        # Wrapper should be callable itself
-        assert callable(wrapper)
+    def test_cache_management_methods(self, client):
+        """Test that cache management methods are available."""
+        assert hasattr(client, "clear_cache")
+        assert hasattr(client, "cache_stats")
+        assert callable(client.clear_cache)
+        assert callable(client.cache_stats)
+
+    def test_context_manager_support(self, client):
+        """Test that context manager protocol is supported."""
+        assert hasattr(client, "__enter__")
+        assert hasattr(client, "__exit__")
+        assert hasattr(client, "close")
+
+        # Should be usable as context manager
+        with client:
+            pass  # Should not raise


### PR DESCRIPTION
- Remove dynamic __getattr__ and wrapper classes for cleaner, more predictable API
- Replace PredictableServiceWrapper with direct service object assignment
- Add explicit convenience methods (conceptset_*, cohortdefinition_*, job_status)
- Update tests to match new explicit API structure
- Improve IDE support and maintainability by removing magic method generation
- Bump version to 0.4.0 due to breaking changes
- Remove redundant __version__ from __init__.py (version is managed in pyproject.toml)

BREAKING CHANGE: client.conceptset() and client.cohortdefinition() are no longer callable. Use client.concept_sets.list() and client.cohorts.list() instead. Convenience methods like client.conceptset_expression() remain available.